### PR TITLE
bugfix to truncate output filename to 100 characters

### DIFF
--- a/R/gpmodels_internal.R
+++ b/R/gpmodels_internal.R
@@ -587,13 +587,20 @@ gpm_add_predictors_internal = function(time_frame = NULL,
               paste0(filename_prefix, file_type, '_category_', category, '_', lubridate::now()) %>%
                 janitor::make_clean_names() %>%
                 paste0('.csv'))
-  } else {
-    file.path(time_frame$output_folder,
-              paste0(filename_prefix, file_type, '_variables_', paste0(variables, collapse = '_'),
-                     '_', lubridate::now()) %>%
-                janitor::make_clean_names() %>%
-                paste0('.csv'))
-  }
+} else {
+  # BUGFIX checks total pathname and truncates from variable name(s)
+  path_length = nchar(file.path(time_frame$output_folder, paste0(filename_prefix, file_type, '_variables_', '_', lubridate::now(), '.csv')))
+  var_length = nchar(paste0(variables, collapse = '_'))
+  if(path_length + var_length > 100) {
+    new_var_length = (100 - path_length)
+    message("Filename truncated due to length")
+  } else (new_var_length = var_length)
+  file.path(time_frame$output_folder,
+            paste0(filename_prefix, file_type, '_variables_', substring(paste0(variables, collapse = '_'), 0, new_var_length),
+                   '_', lubridate::now()) %>%
+              janitor::make_clean_names() %>%
+              paste0('.csv'))
+}
 
 
   if (output_file == TRUE) {


### PR DESCRIPTION
bugfix to truncate filename to 100 characters when variable names exceed the allowable path length.